### PR TITLE
fix: create "checkout" command

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,14 +25,15 @@
   "private": false,
   "dependencies": {
     "@apollo/client": "^3.7.17",
-    "clifer": "^1.1.2",
+    "clifer": "^1.1.3",
     "express": "^4.18.2",
     "fs-extra": "^11.1.1",
     "gql-hook-codegen": "^1.0.17",
     "graphql": "^16.7.1",
     "node-fetch": "2.6.6",
     "open": "^9.1.0",
-    "react": "^18.2.0"
+    "react": "^18.2.0",
+    "shelljs": "^0.8.5"
   },
   "devDependencies": {
     "@types/express": "^4.17.17",
@@ -40,6 +41,7 @@
     "@types/jest": "^29.0.1",
     "@types/node": "^18.7.16",
     "@types/node-fetch": "^2.6.4",
+    "@types/shelljs": "^0.8.12",
     "@typescript-eslint/eslint-plugin": "^5.36.2",
     "@typescript-eslint/parser": "^5.36.2",
     "eslint": "^8.23.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "node-fetch": "2.6.6",
     "open": "^9.1.0",
     "react": "^18.2.0",
-    "shelljs": "^0.8.5"
+    "shelljs": "^0.8.5",
+    "string-width": "2.0.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.17",

--- a/src/commands/cache/cache.ts
+++ b/src/commands/cache/cache.ts
@@ -1,0 +1,32 @@
+import fs from 'fs-extra'
+
+interface Cache {
+  checkoutToken?: string
+}
+
+const defaultConfig: Cache = {}
+
+function toPaths(projectRoot: string) {
+  const configPath = `${projectRoot}/.hypergraph`
+  const configFile = `${configPath}/cache.json`
+  return [configPath, configFile]
+}
+
+export function readCache(projectRoot: string) {
+  try {
+    const [configPath, configFile] = toPaths(projectRoot)
+    fs.ensureDirSync(configPath)
+    const currentConfig = fs.readJSONSync(configFile) ?? {}
+    return currentConfig as Cache
+  } catch {
+    return defaultConfig
+  }
+}
+
+export function saveCache(projectRoot: string, changedConfig: Cache) {
+  const [configPath, configFile] = toPaths(projectRoot)
+  fs.ensureDirSync(configPath)
+  const currentConfig = readCache(projectRoot)
+  const finalConfig = { ...defaultConfig, ...currentConfig, ...changedConfig }
+  fs.writeFileSync(configFile, JSON.stringify(finalConfig, null, 2))
+}

--- a/src/commands/checkout/use-checkout-query.gql.ts
+++ b/src/commands/checkout/use-checkout-query.gql.ts
@@ -2,24 +2,34 @@ import { QueryHookOptions, useQuery } from '../../graphql'
 import gql from 'graphql-tag'
 
 const query = gql`
-  query fetchCheckout($projectId: String!) {
-    checkout(projectId: $projectId) {
-      id
-      name
-      sourceFiles {
-        fileName
-        content
+  query fetchCheckout($next: String, $projectId: String!) {
+    checkout(next: $next, projectId: $projectId) {
+      next
+      project {
+        id
+        name
+        sourceFiles {
+          fileName
+          content
+        }
       }
     }
   }
 `
 
 export interface RequestType {
+  next?: string | undefined
   projectId: string | undefined
 }
 
 export interface QueryType {
-  checkout: ProjectType
+  checkout: CheckoutResponseType
+}
+
+export interface CheckoutResponseType {
+  next?: string
+  project: ProjectType
+  __typename?: 'CheckoutResponse'
 }
 
 export interface ProjectType {

--- a/src/commands/project/project-service.ts
+++ b/src/commands/project/project-service.ts
@@ -25,8 +25,7 @@ export async function chooseAProject(projects: Project[], currentProject?: Proje
       .default(formatProject(currentProject)),
   )
   const [, projectId] = /.+\((.+)\)$/.exec(project) ?? []
-  const selectedProject = selectProjectById(projects, projectId)
-  return selectedProject
+  return selectProjectById(projects, projectId)
 }
 
 export async function showCurrentProject(projects: Project[]) {

--- a/src/commands/project/project-service.ts
+++ b/src/commands/project/project-service.ts
@@ -62,7 +62,7 @@ export async function fetchProjects() {
   } catch (e) {
     if (/You are unauthorized/.test(e.message)) {
       throw new Error(
-        'Error: Unable to access projects. Make sure you are logged in to select a project using "hypergraph login".',
+        'Error: Unable to access projects. Make sure you are logged in to select a project using "hypergraph auth login".',
       )
     }
     throw e

--- a/src/util/run-command.ts
+++ b/src/util/run-command.ts
@@ -1,0 +1,36 @@
+import { yellow } from 'chalk'
+import { exec } from 'shelljs'
+
+interface Options {
+  silent?: boolean
+  fatal?: boolean
+  cwd?: string
+}
+
+function showCommand(command: string) {
+  console.log(
+    yellow(
+      `\n$ ${command
+        .split(/\n|\s/)
+        .map(i => i.trim())
+        .filter(i => !!i)
+        .join(' ')}`,
+    ),
+  )
+}
+
+export function runCommand(
+  command: string,
+  { fatal = true, silent = false, cwd = process.cwd() }: Options = {},
+) {
+  if (!silent) showCommand(command)
+  return new Promise<string[]>((resolve, reject) => {
+    exec(command, { silent, fatal, cwd }, async (code, stdout, stderr) => {
+      if (code !== 0) {
+        reject((stderr ?? stdout ?? '').split('\n'))
+      } else {
+        resolve((stdout ?? stderr ?? '').split('\n'))
+      }
+    })
+  })
+}

--- a/src/util/source-file-util.ts
+++ b/src/util/source-file-util.ts
@@ -1,0 +1,50 @@
+import { green, yellow } from 'chalk'
+import { ensureDir, exists, readFile, writeFile } from 'fs-extra'
+import { basename, dirname, extname, resolve } from 'path'
+import { format } from 'prettier'
+
+async function shouldIgnoreFile(file: string) {
+  const hasFile = await exists(file)
+  if (!hasFile) return false
+  const content = await readFile(file, 'utf-8')
+  return content.split('\n').find(line => /@hg-ignore/.test(line)) !== undefined
+}
+export function prettify(code: string) {
+  return format(code, {
+    arrowParens: 'avoid',
+    bracketSpacing: true,
+    endOfLine: 'lf',
+    htmlWhitespaceSensitivity: 'css',
+    jsxSingleQuote: true,
+    printWidth: 100,
+    proseWrap: 'always',
+    requirePragma: false,
+    semi: false,
+    singleQuote: true,
+    tabWidth: 2,
+    trailingComma: 'all',
+    useTabs: false,
+    parser: 'typescript',
+  } as any)
+}
+
+export function writeSourceFiles(
+  root: string,
+  sourceFiles: Array<{ fileName: string; content: string[] }>,
+) {
+  return Promise.all(
+    sourceFiles.map(async sourceFile => {
+      const dir = resolve(root, dirname(sourceFile.fileName))
+      const file = resolve(dir, basename(sourceFile.fileName))
+      if ((await shouldIgnoreFile(file)) === true) return
+      const fileExists = (await exists(file)) === true
+      await ensureDir(dir)
+      console.log(`${fileExists ? yellow('[UPDATE]') : green('[CREATE]')} ${sourceFile.fileName}`)
+      const extension = extname(file)
+      const fileContent = sourceFile.content.join('\n')
+      const content = extension === '.ts' ? prettify(fileContent) : fileContent
+      await writeFile(file, content, 'utf-8')
+      return { ...sourceFile, content: content.split('\n') }
+    }),
+  )
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1579,6 +1579,11 @@ ansi-escapes@^6.2.0:
   dependencies:
     type-fest "^3.0.0"
 
+ansi-regex@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
+  integrity sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==
+
 ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
@@ -3616,6 +3621,11 @@ is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
   integrity sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==
+
+is-fullwidth-code-point@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
+  integrity sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==
 
 is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
@@ -6230,6 +6240,14 @@ string-length@^4.0.1:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
+string-width@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.0.0.tgz#635c5436cc72a6e0c387ceca278d4e2eec52687e"
+  integrity sha512-w+YQpeOppRYnIHRftgHpjGYUj9m0XKeam1C4ahbh+vErWcY8JJCcrHi/YhUFhHoVeWADkhplCWYdYwX5Nmhiyw==
+  dependencies:
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^3.0.0"
+
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.1.2.tgz#14f8daec6d81e7221d2a357e668cab73bdbca794"
@@ -6259,6 +6277,13 @@ string_decoder@~1.1.1:
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
   dependencies:
     ansi-regex "^5.0.1"
+
+strip-ansi@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
+  integrity sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==
+  dependencies:
+    ansi-regex "^2.0.0"
 
 strip-ansi@^7.0.1:
   version "7.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1177,6 +1177,14 @@
     "@types/jsonfile" "*"
     "@types/node" "*"
 
+"@types/glob@~7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.2.0.tgz#bc1b5bf3aa92f25bd5dd39f35c57361bdce5b2eb"
+  integrity sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==
+  dependencies:
+    "@types/minimatch" "*"
+    "@types/node" "*"
+
 "@types/graceful-fs@^4.1.3":
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.6.tgz#e14b2576a1c25026b7f02ede1de3b84c3a1efeae"
@@ -1237,6 +1245,11 @@
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.2.tgz#93e25bf9ee75fe0fd80b594bc4feb0e862111b5a"
   integrity sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==
+
+"@types/minimatch@*":
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-5.1.2.tgz#07508b45797cb81ec3f273011b054cd0755eddca"
+  integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
 
 "@types/minimist@^1.2.0":
   version "1.2.2"
@@ -1301,6 +1314,14 @@
   dependencies:
     "@types/http-errors" "*"
     "@types/mime" "*"
+    "@types/node" "*"
+
+"@types/shelljs@^0.8.12":
+  version "0.8.12"
+  resolved "https://registry.yarnpkg.com/@types/shelljs/-/shelljs-0.8.12.tgz#79dc9632af7d5ca1b5afb65a6bfc1422d79b5fa0"
+  integrity sha512-ZA8U81/gldY+rR5zl/7HSHrG2KDfEb3lzG6uCUDhW1DTQE9yC/VBQ45fXnXq8f3CgInfhZmjtdu/WOUlrXRQUg==
+  dependencies:
+    "@types/glob" "~7.2.0"
     "@types/node" "*"
 
 "@types/stack-utils@^2.0.0":
@@ -2057,10 +2078,10 @@ cli-truncate@^2.1.0:
     slice-ansi "^3.0.0"
     string-width "^4.2.0"
 
-clifer@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/clifer/-/clifer-1.1.2.tgz#f6a0f44317eccf9d610d8ee8e336026222b233f7"
-  integrity sha512-hYKsa804KlNTGlVw2fbzcPGjtdK/hC31let9V7zuhrTUZ2XpW5E6LqBuOqtmE7K+w99F8Bb29IWHrzg7Zpvc5g==
+clifer@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/clifer/-/clifer-1.1.3.tgz#c65596e4d266d1366d33856cab906c7c734e8e9f"
+  integrity sha512-nF8pafhTNrgL/+Ln1akXmqZMsbEUffH293g7idu+vMykV8JmN4dqKQMkEA7YCJRX7MPbgKQWmJDes4TtkgoQhA==
   dependencies:
     chalk "4.1.2"
     enquirer "^2.3.6"
@@ -3140,7 +3161,7 @@ glob@^10.2.5:
     minipass "^5.0.0 || ^6.0.2"
     path-scurry "^1.10.0"
 
-glob@^7.1.3, glob@^7.1.4:
+glob@^7.0.0, glob@^7.1.3, glob@^7.1.4:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
@@ -3526,6 +3547,11 @@ ink@^3.0.8:
     wrap-ansi "^6.2.0"
     ws "^7.5.5"
     yoga-layout-prebuilt "^1.9.6"
+
+interpret@^1.0.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
+  integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
 into-stream@^7.0.0:
   version "7.0.0"
@@ -5732,6 +5758,13 @@ readable-stream@^4.1.0:
     process "^0.11.10"
     string_decoder "^1.3.0"
 
+rechoir@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
+  integrity sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==
+  dependencies:
+    resolve "^1.1.6"
+
 redent@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/redent/-/redent-3.0.0.tgz#e557b7998316bb53c9f1f56fa626352c6963059f"
@@ -5781,7 +5814,7 @@ resolve.exports@^2.0.0:
   resolved "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-2.0.2.tgz#f8c934b8e6a13f539e38b7098e2e36134f01e800"
   integrity sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==
 
-resolve@^1.10.0, resolve@^1.20.0:
+resolve@^1.1.6, resolve@^1.10.0, resolve@^1.20.0:
   version "1.22.2"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.2.tgz#0ed0943d4e301867955766c9f3e1ae6d01c6845f"
   integrity sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==
@@ -5989,6 +6022,15 @@ shell-quote@^1.6.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.1.tgz#6dbf4db75515ad5bac63b4f1894c3a154c766680"
   integrity sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==
+
+shelljs@^0.8.5:
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.5.tgz#de055408d8361bed66c669d2f000538ced8ee20c"
+  integrity sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
 
 side-channel@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
This PR adds "checkout" command which  does the following 
- [x] gets all the source files for a project from the server
- [x] creates files locally
- [x] maintains a cache to fetch incrementally using `next` token

```sh
hypergraph checkout   [--project-id=<string>] [--skip-cache] [--help]

OPTIONS

--project-id=<string>   Id of the project to checkout

--skip-cache            Disable cache. By default it is enabled

--help                  Show help
```